### PR TITLE
Clarify gate CLI behavior and enforce semver + release confirmation in wsp skills

### DIFF
--- a/skills/wsp-gate/SKILL.md
+++ b/skills/wsp-gate/SKILL.md
@@ -52,7 +52,7 @@ If no `[gate]` section exists or `enabled = false`, skip all checks and report "
 Each check follows a three-tier priority:
 
 1. **Specialized skill** — if a skill exists for this check, delegate to it
-2. **CLI tool** — run the dedicated CLI; if not installed, **ask the user** before installing
+2. **CLI tool** — run the dedicated CLI when installed
 3. **Generic fallback** — use built-in analysis when nothing better is available
 
 ### `audit` — Dependency Vulnerability Scan
@@ -199,9 +199,8 @@ grep -rE '^mod |^pub mod |^use |^pub use ' src/ --include='*.rs' | \
 4. For each check in [gate].checks:
    a. Attempt tier-1: dedicated skill → if available, delegate and collect result
    b. Attempt tier-2: CLI → check if installed
-      - If not installed: ask user "Install <tool>? (y/n)"
-      - If yes: install it (brew/cargo/npm/pip), proceed
-      - If no: fall through to tier-3
+      - If installed: run it and collect findings
+      - If not installed: record `tool missing` warning and fall through to tier-3 automatically
    c. Fallback to tier-3: generic built-in analysis
 5. Aggregate all check results
 6. Determine gate verdict:
@@ -268,7 +267,7 @@ Or if FAILED:
 
 ## Important Notes
 
-- **Ask before installing**: Never install a CLI tool without user confirmation. The skill should say: "`gitleaks` is not installed. Install it? (y/n)"
+- **No installs during gate run**: If a CLI tool is missing, do not install it during this workflow. Use fallback checks and record the tool as missing in the report.
 - **Respect `.gitignore`**: Skip `node_modules/`, `target/`, `.git/`, `build/` in all file scans
 - **False positives**: When using generic fallbacks, bias toward reporting *potential* issues and let the user decide. Never silently fail a gate on a false positive.
 - **Speed**: Prefer CLI tools over generic fallbacks — they're faster and more accurate. Generic fallbacks are the last resort.

--- a/skills/wsp-opt/SKILL.md
+++ b/skills/wsp-opt/SKILL.md
@@ -65,7 +65,12 @@ Save their answer in the What section. Then ask: "Why does this matter? What pro
 
 Ask the user: "The scope of updates in the current version is: Function (Main) / Patch (Major) / Bug (Minor) / Type your own Version Number ?"
 
-Create a versioned todo file `.wasup/todos/vx.y.z.md` (start with `v1.0.0`, `v0.1.0` or `v.0.0.1`, based on the update scope selected by the user: Function to add 1 on `x`, Patch to add 1 on `y` and Bug to add 1 on `z`).
+Create a versioned todo file `.wasup/todos/vx.y.z.md` using strict semver format only (`vX.Y.Z`, for example `v1.0.0`, `v0.1.0`, `v0.0.1`).
+
+Version bump rules:
+- **Function (Main)**: bump major (`x`) and reset minor/patch to zero.
+- **Patch (Major)**: bump minor (`y`) and reset patch to zero.
+- **Bug (Minor)**: bump patch (`z`) only.
 
 Then update the `current_version` inside `.wasup/wasup.toml`.
 
@@ -180,6 +185,18 @@ After the review finishes, re-run it with fresh context. Repeat until every todo
 ### Tag and Merge
 
 Ask user: "Which branch should the current branch be merged into, dev or master?"
+
+Before running any release command, present a final release checklist and require explicit confirmation:
+
+```markdown
+Release plan for confirmation:
+- Version tag: vx.y.z
+- Source branch: feat/vx.y.z-<short-description>
+- Target branch: master|dev
+- Commands to run: git tag, git checkout, git merge, git push, git push --tags
+```
+
+If the user does not explicitly confirm, stop and do not run any release commands.
 
 ```bash
 git tag -a v0.1.0 -m "Release v0.1.0"


### PR DESCRIPTION
### Motivation
- Make the gate workflow non-interactive and deterministic by preventing runtime installations of CLI tools. 
- Enforce strict semantic versioning for todo files and make version bumping rules explicit. 
- Require explicit user confirmation before performing release actions to avoid accidental tags/merges. 

### Description
- Update `skills/wsp-gate/SKILL.md` to change tier-2 behavior so CLIs are only run when installed, missing tools are recorded as `tool missing`, and no CLI is installed during the gate run. 
- Adjust the execution flow and important notes to reflect the new non-install policy and to prefer CLI tools but fall back to generic analysis automatically. 
- Update `skills/wsp-opt/SKILL.md` to require strict semver format for `.wasup/todos/vx.y.z.md`, add explicit version bump rules for Function/Patch/Bug modes, and add a release checklist that requires explicit confirmation before running release commands. 

### Testing
- No automated tests were added or executed as these are documentation and workflow specification changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c537278e8832194e5a97271f78e3b)